### PR TITLE
TCS-652 | Switch from PHP 7.0 to 7.2 in Docker-compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 #      - /path/to/mariadb/data/on/host:/var/lib/mysql # I want to manage volumes manually.
 
   php:
-    image: wodby/drupal-php:7.0-dev-4.6.0
+    image: wodby/drupal-php:7.2-dev-4.8.4
     container_name: "tcs_php"
     environment:
       PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025


### PR DESCRIPTION
CasperJS test ran both before (on v7.0) and after (on v7.2) with fully green results.