### PR TITLE
TCS-652 | Require PHP 7.2 version in Composer.json too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         }
     },
     "require": {
-        "php": "~7.0",
+        "php": "~7.2",
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "^2.2",
         "cweagans/composer-patches": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ddf731a36cc3d9c965a029d9f03f58a",
+    "content-hash": "22c807c4ddd61787e8ae325e29a55bad",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1069,11 +1069,6 @@
         {
             "name": "drupal-composer/drupal-security-advisories",
             "version": "8.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/drupal-composer/drupal-security-advisories.git",
-                "reference": "fbfcf3499c18873405dd72751a567bf208943eb4"
-            },
             "conflict": {
                 "drupal/acquia_contenthub": "<1.0,<1.4",
                 "drupal/alinks": "<1.1",
@@ -11015,7 +11010,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.0"
+        "php": "~7.2"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
I realized today that somehow inconsistency happened between the PHP version declared:

* [docker-compose.yml](/brainsum/tcs/blob/e4ab27616f2f82b7805c3fe4b6b7ccfe07a71c5a/docker-compose.yml#L18) refers to 7.2
* [composer.json](/brainsum/tcs/blob/e4ab27616f2f82b7805c3fe4b6b7ccfe07a71c5a/composer.json#L43) refers to 7.0

This is because my commit [ae5f1d1](/brainsum/tcs/commit/cd99831fe349750c1ef35f341a3e30d9c) affected only the former one, but _not_ the latter one, which is bad. Although it has no serious effect on current sites working, but it will have in the future when a new site instance is being installed. This is my mistake, so here I fix it.